### PR TITLE
Add support for creating an empty clojure file

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,12 +23,21 @@
   </change-notes>
 
   <actions>
+    <action id="Clojure.NewClojureFile"
+            class="org.intellij.clojure.actions.file.ClojureCreateFileFromTemplateAction"
+            text="Clojure File"
+            description="Create new Clojure file">
+      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+    </action>
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
     <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
 
     <fileTypeFactory implementation="org.intellij.clojure.lang.ClojureFileTypeFactory"/>
+    <internalFileTemplate name="new-clojure-file"/>
+
+
     <lang.parserDefinition language="Clojure" implementationClass="org.intellij.clojure.parser.ClojureParserDefinition"/>
     <lang.parserDefinition language="ClojureScript" implementationClass="org.intellij.clojure.parser.ClojureScriptParserDefinition"/>
     <lang.substitutor language="Clojure" implementationClass="org.intellij.clojure.lang.ClojureLanguageSubstitutor"/>

--- a/resources/fileTemplates/internal/new-clojure-file.clj.html
+++ b/resources/fileTemplates/internal/new-clojure-file.clj.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Empty Clojure file.
+</body>
+</html>

--- a/src/actions/file/ClojureCreateFileFromTemplateAction.kt
+++ b/src/actions/file/ClojureCreateFileFromTemplateAction.kt
@@ -1,0 +1,25 @@
+package org.intellij.clojure.actions.file
+
+import com.intellij.ide.actions.CreateFileFromTemplateAction
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDirectory
+import org.intellij.clojure.ClojureIcons
+
+class ClojureCreateFileFromTemplateAction : CreateFileFromTemplateAction(ClojureCreateFileFromTemplateAction.CAPTION, "", ClojureIcons.CLOJURE_ICON), DumbAware {
+
+    override fun getActionName(directory: PsiDirectory?, newName: String?, templateName: String?): String = CAPTION
+
+    override fun buildDialog(project: Project?,
+                             directory: PsiDirectory?,
+                             builder: CreateFileFromTemplateDialog.Builder) {
+        builder.setTitle(CAPTION)
+                .addKind("Empty File", ClojureIcons.CLOJURE_ICON, ClojureCreateFileFromTemplateAction.TEMPLATE_FILENAME)
+    }
+
+    private companion object {
+        private val TEMPLATE_FILENAME = "new-clojure-file"
+        private val CAPTION = "New Clojure File"
+    }
+}


### PR DESCRIPTION
Users of the plugin can create a new Clojure file by either using the menu (File > New > Clojure File) or by using the Alt + Insert shortcut in the project view. 

The default Clojure file template is empty.