### PR TITLE
Resolve transitive dependencies

### DIFF
--- a/src/tools/tools.kt
+++ b/src/tools/tools.kt
@@ -121,7 +121,7 @@ object Deps : Tool {
   override fun getDeps(projectFile: File) = readProcessOutput(
       GeneralCommandLine(command, "-Stree"), projectFile.parent)
       .mapNotNull { line ->
-        Regex("(.*)/(.*) (.*)").matchEntire(line.trim())?.let {
+        Regex("(?:\\. )?(.*)/(.*) (.*)").matchEntire(line.trim())?.let {
           val (group, artifact, version) = it.destructured
           Dependency(group, artifact, version)
         }


### PR DESCRIPTION
Fixes #42 by excluding `. ` prepended to transitive dependencies when parsing the output of `clojure -Stree`.

For example,

```
duct/core 0.8.0
  . integrant/integrant 0.7.0
    . weavejester/dependency 0.2.1
  . medley/medley 1.2.0
```